### PR TITLE
Fixed the remaining usage of Sizes with Shape.sizes()

### DIFF
--- a/include/polly/CodeGen/IslExprBuilder.h
+++ b/include/polly/CodeGen/IslExprBuilder.h
@@ -93,7 +93,9 @@ class IslExprBuilder {
 public:
   /// A map from isl_ids to llvm::Values.
   typedef llvm::MapVector<isl_id *, llvm::AssertingVH<llvm::Value>> IDToValueTy;
-
+  /// A map from const SCEV* to llvm::Values
+  typedef llvm::MapVector<const llvm::SCEV *, llvm::AssertingVH<llvm::Value>>
+      SCEVToValueTy;
   typedef llvm::MapVector<isl_id *, const ScopArrayInfo *> IDToScopArrayInfoTy;
 
   /// A map from isl_ids to ScopArrayInfo objects.
@@ -131,9 +133,10 @@ public:
   /// @param LI          LoopInfo analysis for the current function.
   /// @param StartBlock The first basic block after the RTC.
   IslExprBuilder(Scop &S, PollyIRBuilder &Builder, IDToValueTy &IDToValue,
-                 ValueMapT &GlobalMap, const llvm::DataLayout &DL,
-                 llvm::ScalarEvolution &SE, llvm::DominatorTree &DT,
-                 llvm::LoopInfo &LI, llvm::BasicBlock *StartBlock);
+                 SCEVToValueTy &SCEVToValue, ValueMapT &GlobalMap,
+                 const llvm::DataLayout &DL, llvm::ScalarEvolution &SE,
+                 llvm::DominatorTree &DT, llvm::LoopInfo &LI,
+                 llvm::BasicBlock *StartBlock);
 
   /// Create LLVM-IR for an isl_ast_expr[ession].
   ///
@@ -210,6 +213,7 @@ private:
 
   PollyIRBuilder &Builder;
   IDToValueTy &IDToValue;
+  SCEVToValueTy &SCEVToValue;
   ValueMapT &GlobalMap;
 
   const llvm::DataLayout &DL;
@@ -272,6 +276,10 @@ private:
   /// @return A value that represents the result of the multiplication.
   llvm::Value *createMul(llvm::Value *LHS, llvm::Value *RHS,
                          const llvm::Twine &Name = "");
+
+  // Provide a uniform interface to lookup replacements of the old value
+  // in the various maps we provide.
+  llvm::Value *getLatestValue(llvm::Value *Old);
 };
 } // namespace polly
 

--- a/include/polly/CodeGen/IslExprBuilder.h
+++ b/include/polly/CodeGen/IslExprBuilder.h
@@ -277,8 +277,8 @@ private:
   llvm::Value *createMul(llvm::Value *LHS, llvm::Value *RHS,
                          const llvm::Twine &Name = "");
 
-  // Provide a uniform interface to lookup replacements of the old value
-  // in the various maps we provide.
+  /// Provide a uniform interface to lookup replacements of the old value
+  /// in the various maps we provide.
   llvm::Value *getLatestValue(llvm::Value *Old);
 };
 } // namespace polly

--- a/include/polly/CodeGen/IslNodeBuilder.h
+++ b/include/polly/CodeGen/IslNodeBuilder.h
@@ -98,8 +98,8 @@ public:
                  const DataLayout &DL, LoopInfo &LI, ScalarEvolution &SE,
                  DominatorTree &DT, Scop &S, BasicBlock *StartBlock)
       : S(S), Builder(Builder), Annotator(Annotator),
-        ExprBuilder(S, Builder, IDToValue, ValueMap, DL, SE, DT, LI,
-                    StartBlock),
+        ExprBuilder(S, Builder, IDToValue, SCEVToValue, ValueMap, DL, SE, DT,
+                    LI, StartBlock),
         BlockGen(Builder, LI, SE, DT, ScalarMap, EscapeMap, ValueMap,
                  &ExprBuilder, StartBlock),
         RegionGen(BlockGen), DL(DL), LI(LI), SE(SE), DT(DT),
@@ -196,6 +196,10 @@ protected:
   // ivs.
   IslExprBuilder::IDToValueTy IDToValue;
 
+  // This maps a const SCEV* to the Value* it has in the generated program. For
+  // now, this stores strides and offsets of SAIs.
+  IslExprBuilder::SCEVToValueTy SCEVToValue;
+
   /// A collection of all parallel subfunctions that have been created.
   SmallVector<Function *, 8> ParallelSubfunctions;
 
@@ -228,6 +232,8 @@ protected:
   ///
   /// @returns False, iff a problem occurred and the value was not materialized.
   bool materializeParameters();
+
+  void materializeStridedArraySizes();
 
   // Extract the upper bound of this loop
   //

--- a/include/polly/ScopBuilder.h
+++ b/include/polly/ScopBuilder.h
@@ -186,6 +186,8 @@ class ScopBuilder {
   /// @param Stmt       The parent statement of the instruction
   void buildAccessSingleDim(MemAccInst Inst, ScopStmt *Stmt);
 
+  bool buildAccessPollyAbstractIndex(MemAccInst Inst, ScopStmt *Stmt);
+
   /// Build an instance of MemoryAccess from the Load/Store instruction.
   ///
   /// @param Inst       The Load/Store instruction that access the memory
@@ -278,7 +280,7 @@ class ScopBuilder {
                                 Value *BaseAddress, Type *ElemType, bool Affine,
                                 Value *AccessValue,
                                 ArrayRef<const SCEV *> Subscripts,
-                                ArrayRef<const SCEV *> Sizes, MemoryKind Kind);
+                                ShapeInfo Shape, MemoryKind Kind);
 
   /// Create a MemoryAccess that represents either a LoadInst or
   /// StoreInst.
@@ -297,8 +299,8 @@ class ScopBuilder {
   void addArrayAccess(ScopStmt *Stmt, MemAccInst MemAccInst,
                       MemoryAccess::AccessType AccType, Value *BaseAddress,
                       Type *ElemType, bool IsAffine,
-                      ArrayRef<const SCEV *> Subscripts,
-                      ArrayRef<const SCEV *> Sizes, Value *AccessValue);
+                      ArrayRef<const SCEV *> Subscripts, ShapeInfo Shape,
+                      Value *AccessValue);
 
   /// Create a MemoryAccess for writing an llvm::Instruction.
   ///

--- a/include/polly/ScopInfo.h
+++ b/include/polly/ScopInfo.h
@@ -108,6 +108,189 @@ enum AssumptionKind {
   DELINEARIZATION,
 };
 
+// Abstract over a notion of the shape of an array:
+// Once can compute indeces using both sizes and strides.
+class ShapeInfo {
+private:
+  using SCEVArrayTy = SmallVector<const SCEV *, 4>;
+  using SCEVArrayRefTy = ArrayRef<const SCEV *>;
+
+  using OptionalSCEVArrayTy = Optional<SCEVArrayTy>;
+  using OptionalSCEVArrayRefTy = Optional<SCEVArrayRefTy>;
+
+  llvm::Optional<SmallVector<const SCEV *, 4>> Sizes;
+  llvm::Optional<SmallVector<const SCEV *, 4>> Strides;
+  llvm::Optional<const SCEV *> Offset;
+
+  ShapeInfo(Optional<ArrayRef<const SCEV *>> SizesRef,
+            Optional<ArrayRef<const SCEV *>> StridesRef,
+            llvm::Optional<const SCEV *> Offset)
+      : Offset(Offset) {
+    // Can check for XOR
+    assert(bool(SizesRef) || bool(StridesRef));
+    assert(!(bool(SizesRef) && bool(StridesRef)));
+
+    if (StridesRef || Offset) {
+      assert(Offset);
+      assert(StridesRef);
+    }
+
+    if (SizesRef)
+      Sizes =
+          OptionalSCEVArrayTy(SCEVArrayTy(SizesRef->begin(), SizesRef->end()));
+
+    if (StridesRef)
+      Strides = OptionalSCEVArrayTy(
+          SCEVArrayTy(StridesRef->begin(), StridesRef->end()));
+  }
+
+  ShapeInfo(NoneType) : Sizes(None), Strides(None), Offset(None) {}
+
+public:
+  static ShapeInfo fromSizes(ArrayRef<const SCEV *> Sizes) {
+    return ShapeInfo(OptionalSCEVArrayRefTy(Sizes), None, None);
+  }
+
+  // We have this anti-pattern in polly which does this:
+  // Shape(ShapeInfo::fromSizes({nullptr})
+  // Consider providing a separate constructor for this, which we then
+  // kill in some cleanup.
+
+  ShapeInfo(const ShapeInfo &other) {
+    Sizes = other.Sizes;
+    Strides = other.Strides;
+    Offset = other.Offset;
+  }
+
+  ShapeInfo &operator=(const ShapeInfo &other) {
+    Sizes = other.Sizes;
+    Strides = other.Strides;
+    Offset = other.Offset;
+    return *this;
+  }
+
+  static ShapeInfo fromStrides(ArrayRef<const SCEV *> Strides,
+                               const SCEV *Offset) {
+    assert(Offset && "offset is null");
+    return ShapeInfo(None, OptionalSCEVArrayRefTy(Strides),
+                     Optional<const SCEV *>(Offset));
+  }
+
+  static ShapeInfo none() { return ShapeInfo(None); }
+
+  unsigned getNumberOfDimensions() const {
+    // assert(isInitialized());
+    if (Sizes)
+      return Sizes->size();
+
+    if (Strides)
+      return Strides->size();
+
+    return 0;
+  }
+
+  /// Set the sizes of the Shape. It checks the invariant
+  /// That this shape does not have strides.
+  void setSizes(SmallVector<const SCEV *, 4> NewSizes) {
+    assert(!bool(Strides));
+
+    if (!bool(Sizes)) {
+      Sizes = Optional<SmallVector<const SCEV *, 4>>(
+          SmallVector<const SCEV *, 4>());
+    }
+
+    Sizes = NewSizes;
+  }
+
+  /// Set the strides of the Shape. It checks the invariant
+  /// That this shape does not have sizes.
+  void setStrides(ArrayRef<const SCEV *> NewStrides, const SCEV *NewOffset) {
+    Offset = NewOffset;
+    assert(!bool(Sizes));
+
+    // Be explicit because GCC(5.3.0) is unable to deduce this.
+    if (!Strides)
+      Strides = Optional<SmallVector<const SCEV *, 4>>(
+          SmallVector<const SCEV *, 4>());
+
+    Strides->clear();
+    Strides->insert(Strides->begin(), NewStrides.begin(), NewStrides.end());
+
+    assert(Offset && "offset is null");
+  }
+
+  const SmallVector<const SCEV *, 4> &sizes() const {
+    assert(!bool(Strides));
+    return Sizes.getValue();
+  }
+
+  const SCEV *offset() const { return Offset.getValue(); }
+
+  SmallVector<const SCEV *, 4> &sizes_mut() {
+    assert(!bool(Strides));
+    return Sizes.getValue();
+  }
+
+  bool isInitialized() const { return bool(Sizes) || bool(Strides); }
+
+  const SmallVector<const SCEV *, 4> &strides() const {
+    assert(!bool(Sizes));
+    return Strides.getValue();
+  }
+
+  const SmallVector<const SCEV *, 4> &getSizesOrStrides() {
+    if (Sizes)
+      return Sizes.getValue();
+
+    if (Strides)
+      return Strides.getValue();
+  }
+  bool hasSizes() const { return bool(Sizes); }
+  bool hasStrides() const { return bool(Strides); }
+
+  template <typename Ret>
+  Ret mapSizes(std::function<Ret(SmallVector<const SCEV *, 4> &)> func,
+               Ret otherwise) {
+    if (Sizes)
+      return func(*Sizes);
+
+    return otherwise;
+  }
+
+  void mapSizes(std::function<void(SmallVector<const SCEV *, 4> &)> func) {
+    if (Sizes)
+      func(*Sizes);
+  }
+
+  raw_ostream &print(raw_ostream &OS) const {
+    if (Sizes) {
+      OS << "Sizes: ";
+      for (auto Size : *Sizes) {
+        if (Size)
+          OS << *Size << ", ";
+        else
+          OS << "null"
+             << ", ";
+      }
+      return OS;
+    } else if (Strides) {
+      OS << "Strides: ";
+      for (auto Stride : *Strides) {
+        if (Stride)
+          OS << *Stride << ", ";
+        else
+          OS << "null"
+             << ", ";
+      }
+      return OS;
+    }
+    OS << "Uninitialized.\n";
+    return OS;
+  }
+};
+
+raw_ostream &operator<<(raw_ostream &OS, const ShapeInfo &Shape);
+
 /// Enum to distinguish between assumptions and restrictions.
 enum AssumptionSign { AS_ASSUMPTION, AS_RESTRICTION };
 
@@ -256,14 +439,15 @@ public:
   /// @param BasePtr        The array base pointer.
   /// @param ElementType    The type of the elements stored in the array.
   /// @param IslCtx         The isl context used to create the base pointer id.
+  /// @param ShapeInfo
   /// @param DimensionSizes A vector containing the size of each dimension.
   /// @param Kind           The kind of the array object.
   /// @param DL             The data layout of the module.
   /// @param S              The scop this array object belongs to.
   /// @param BaseName       The optional name of this memory reference.
   ScopArrayInfo(Value *BasePtr, Type *ElementType, isl::ctx IslCtx,
-                ArrayRef<const SCEV *> DimensionSizes, MemoryKind Kind,
-                const DataLayout &DL, Scop *S, const char *BaseName = nullptr);
+                ShapeInfo Shape, MemoryKind Kind, const DataLayout &DL, Scop *S,
+                const char *BaseName = nullptr);
 
   /// Destructor to free the isl id of the base pointer.
   ~ScopArrayInfo();
@@ -292,6 +476,28 @@ public:
   ///                          with old sizes
   bool updateSizes(ArrayRef<const SCEV *> Sizes, bool CheckConsistency = true);
 
+  /// Update the strides of a ScopArrayInfo object, when we had
+  /// initially believed it to be a size based representation, we later
+  /// get a more refined view of the array in terms of strides.
+  /// TODO: Think if this is really necessary. We needed this in COSMO for
+  /// reasons, (IIRC, they would have <baseptr> be a i8*, which they would index
+  /// "correctly"
+  ///  to get to the offset and stride info.)
+  /// Roughly, they had code like this:
+  ///   struct ARRTY { int64 offset; int64 stride_1; int64 stride_2; void
+  ///   *memory; } void * arr; offset = ((int64 *)arr)[0]; stride_1 = ((int64
+  ///   *)arr)[1]; stride_2 = ((int64 *)arr)[1]; memory =
+  ///   fortran_index(((char*)arr+<correct offset>)), offset, stride_1,
+  ///   stride_2, ix1, ix2); In this type of code, we would first see the naked
+  ///   access of "arr" which we would represent in a size based repr, and we
+  ///   would change our view later into the strided version. We should probably
+  ///   disallow this for future clients.
+  void overwriteSizeWithStrides(ArrayRef<const SCEV *> Strides,
+                                const SCEV *Offset);
+
+  /// Update the strides of a ScopArrayInfo object.
+  bool updateStrides(ArrayRef<const SCEV *> Strides, const SCEV *Offset);
+
   /// Make the ScopArrayInfo model a Fortran array.
   /// It receives the Fortran array descriptor and stores this.
   /// It also adds a piecewise expression for the outermost dimension
@@ -311,6 +517,9 @@ public:
   // Set IsOnHeap to the value in parameter.
   void setIsOnHeap(bool value) { IsOnHeap = value; }
 
+  // get the shape of the ScopArrayInfo
+  ShapeInfo getShape() const { return Shape; }
+
   /// For indirect accesses return the origin SAI of the BP, else null.
   const ScopArrayInfo *getBasePtrOriginSAI() const { return BasePtrOriginSAI; }
 
@@ -324,7 +533,7 @@ public:
     if (Kind == MemoryKind::PHI || Kind == MemoryKind::ExitPHI ||
         Kind == MemoryKind::Value)
       return 0;
-    return DimensionSizes.size();
+    return Shape.getNumberOfDimensions();
   }
 
   /// Return the size of dimension @p dim as SCEV*.
@@ -334,8 +543,15 @@ public:
   //  information, in case the array is not newly created.
   const SCEV *getDimensionSize(unsigned Dim) const {
     assert(Dim < getNumberOfDimensions() && "Invalid dimension");
-    return DimensionSizes[Dim];
+    return Shape.sizes()[Dim];
   }
+
+  const SCEV *getDimensionStride(unsigned Dim) const {
+    assert(Dim < getNumberOfDimensions() && "Invalid dimension");
+    return Shape.strides()[Dim];
+  }
+
+  const SCEV *getStrideOffset() const { return Shape.offset(); }
 
   /// Return the size of dimension @p dim as isl::pw_aff.
   //
@@ -423,6 +639,8 @@ public:
   /// @returns True, if the arrays are compatible, False otherwise.
   bool isCompatibleWith(const ScopArrayInfo *Array) const;
 
+  bool hasStrides() const { return Shape.hasStrides(); }
+
 private:
   void addDerivedSAI(ScopArrayInfo *DerivedSAI) {
     DerivedSAIs.insert(DerivedSAI);
@@ -453,7 +671,7 @@ private:
   bool IsOnHeap = false;
 
   /// The sizes of each dimension as SCEV*.
-  SmallVector<const SCEV *, 4> DimensionSizes;
+  // SmallVector<const SCEV *, 4> DimensionSizes;
 
   /// The sizes of each dimension as isl::pw_aff.
   SmallVector<isl::pw_aff, 4> DimensionSizesPw;
@@ -465,6 +683,9 @@ private:
 
   /// The data layout of the module.
   const DataLayout &DL;
+
+  /// The sizes of each dimension as SCEV*.
+  ShapeInfo Shape;
 
   /// The scop this SAI object belongs to.
   Scop &S;
@@ -586,6 +807,9 @@ private:
 
   /// Type a single array element wrt. this access.
   Type *ElementType;
+
+  /// Size of each dimension of the accessed array.
+  ShapeInfo Shape;
 
   /// Size of each dimension of the accessed array.
   SmallVector<const SCEV *, 4> Sizes;
@@ -756,10 +980,11 @@ public:
   /// @param IsAffine   Whether the subscripts are affine expressions.
   /// @param Kind       The kind of memory accessed.
   /// @param Subscripts Subscript expressions
-  /// @param Sizes      Dimension lengths of the accessed array.
+  /// @param Shape      Shape of the accessed array.
+
   MemoryAccess(ScopStmt *Stmt, Instruction *AccessInst, AccessType AccType,
                Value *BaseAddress, Type *ElemType, bool Affine,
-               ArrayRef<const SCEV *> Subscripts, ArrayRef<const SCEV *> Sizes,
+               ArrayRef<const SCEV *> Subscripts, ShapeInfo Shape,
                Value *AccessValue, MemoryKind Kind);
 
   /// Create a new MemoryAccess that corresponds to @p AccRel.
@@ -2841,13 +3066,13 @@ public:
   const MapInsnToMemAcc &getInsnToMemAccMap() const { return DC.InsnToMemAcc; }
 
   /// Return the (possibly new) ScopArrayInfo object for @p Access.
-  ///
+  /// @param BasePtr     The base  pointer of the SAI to add
   /// @param ElementType The type of the elements stored in this array.
+  /// @param Shape       The shape of the SAI.
   /// @param Kind        The kind of the array info object.
   /// @param BaseName    The optional name of this memory reference.
   ScopArrayInfo *getOrCreateScopArrayInfo(Value *BasePtr, Type *ElementType,
-                                          ArrayRef<const SCEV *> Sizes,
-                                          MemoryKind Kind,
+                                          ShapeInfo Shape, MemoryKind Kind,
                                           const char *BaseName = nullptr);
 
   /// Create an array and return the corresponding ScopArrayInfo object.

--- a/include/polly/ScopInfo.h
+++ b/include/polly/ScopInfo.h
@@ -669,9 +669,6 @@ private:
   /// True if the newly allocated array is on heap.
   bool IsOnHeap = false;
 
-  /// The sizes of each dimension as SCEV*.
-  // SmallVector<const SCEV *, 4> DimensionSizes;
-
   /// The sizes of each dimension as isl::pw_aff.
   SmallVector<isl::pw_aff, 4> DimensionSizesPw;
 

--- a/include/polly/Support/ScopHelper.h
+++ b/include/polly/Support/ScopHelper.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Operator.h"
 #include "llvm/IR/ValueHandle.h"
 #include <tuple>
 #include <vector>
@@ -480,5 +481,12 @@ bool isDebugCall(llvm::Instruction *Inst);
 ///
 /// Such a statement must not be removed, even if has no side-effects.
 bool hasDebugCall(ScopStmt *Stmt);
+
+/// The name of the array index "intrinsic" interpreted by polly
+static const std::string POLLY_ABSTRACT_INDEX_BASENAME = "polly_array_index";
+
+/// Check if a given MemAccInst models a polly_array_index.
+llvm::Optional<std::pair<llvm::CallInst *, llvm::GEPOperator *>>
+getAbstractIndexingCall(MemAccInst Inst, llvm::ScalarEvolution &SE);
 } // namespace polly
 #endif

--- a/lib/Analysis/ScopDetection.cpp
+++ b/lib/Analysis/ScopDetection.cpp
@@ -571,9 +571,8 @@ bool isSCEVMultidimArrayAccess(const SCEV *S) {
 bool ScopDetection::isAffine(const SCEV *S, Loop *Scope,
                              DetectionContext &Context) const {
 
-  if (isSCEVMultidimArrayAccess(S)) {
+  if (isSCEVMultidimArrayAccess(S))
     return true;
-  }
 
   InvariantLoadsSetTy AccessILS;
   if (!isAffineExpr(&Context.CurRegion, Scope, S, SE, &AccessILS))

--- a/lib/Analysis/ScopDetection.cpp
+++ b/lib/Analysis/ScopDetection.cpp
@@ -536,8 +536,45 @@ bool ScopDetection::involvesMultiplePtrs(const SCEV *S0, const SCEV *S1,
   return false;
 }
 
+/// Return if S is a call to a function that we use to denote multidimensional
+// accesses
+bool isSCEVCallToPollyAbstractIndex(const SCEV *S) {
+  if (isa<SCEVUnknown>(S)) {
+    Value *V = cast<SCEVUnknown>(S)->getValue();
+    CallInst *Call = dyn_cast<CallInst>(V);
+    if (Call && Call->getCalledFunction() &&
+        Call->getCalledFunction()->getName().count(
+            POLLY_ABSTRACT_INDEX_BASENAME))
+      return true;
+  }
+  return false;
+}
+
+/// Return if scev represents a multidim access.
+bool isSCEVMultidimArrayAccess(const SCEV *S) {
+  if (isSCEVCallToPollyAbstractIndex(S))
+    return true;
+  const SCEVMulExpr *Mul = dyn_cast<SCEVMulExpr>(S);
+  if (!Mul)
+    return false;
+
+  // TODO: I don't remember why I needed this.
+  // When does a Mul not have two operands? Something like {*, i, *, j, *, k}?
+  if (Mul->getNumOperands() != 2)
+    return false;
+
+  // TODO: I have no memory of why I needed this.
+  return isSCEVCallToPollyAbstractIndex(Mul->getOperand(0)) ||
+         isSCEVCallToPollyAbstractIndex(Mul->getOperand(1));
+}
+
 bool ScopDetection::isAffine(const SCEV *S, Loop *Scope,
                              DetectionContext &Context) const {
+
+  if (isSCEVMultidimArrayAccess(S)) {
+    return true;
+  }
+
   InvariantLoadsSetTy AccessILS;
   if (!isAffineExpr(&Context.CurRegion, Scope, S, SE, &AccessILS))
     return false;
@@ -697,6 +734,11 @@ bool ScopDetection::isValidCallInst(CallInst &CI,
       return true;
 
   Function *CalledFunction = CI.getCalledFunction();
+
+  // Function being called is a polly indexing function.
+  if (CalledFunction->getName().count(POLLY_ABSTRACT_INDEX_BASENAME)) {
+    return true;
+  }
 
   // Indirect calls are not supported.
   if (CalledFunction == nullptr)
@@ -1192,6 +1234,13 @@ bool ScopDetection::isValidAccess(Instruction *Inst, const SCEV *AF,
 
 bool ScopDetection::isValidMemoryAccess(MemAccInst Inst,
                                         DetectionContext &Context) const {
+
+  /// If the memory access is modelling a call of
+  /// polly_abstract_array_index(...)
+  if (getAbstractIndexingCall(Inst, SE)) {
+    return true;
+  }
+
   Value *Ptr = Inst.getPointerOperand();
   Loop *L = LI.getLoopFor(Inst->getParent());
   const SCEV *AccessFunction = SE.getSCEVAtScope(Ptr, L);

--- a/lib/Analysis/ScopInfo.cpp
+++ b/lib/Analysis/ScopInfo.cpp
@@ -4020,7 +4020,7 @@ void Scop::canonicalizeDynamicBasePtrs() {
   }
 }
 
-Value *getPointerFromLoadOrStore(Value *V) {
+static Value *getPointerFromLoadOrStore(Value *V) {
   if (LoadInst *LI = dyn_cast<LoadInst>(V))
     return LI->getPointerOperand();
 
@@ -4061,9 +4061,6 @@ ScopArrayInfo *Scop::getOrCreateScopArrayInfo(Value *BasePtr, Type *ElementType,
 
   auto &SAI = BasePtr ? ScopArrayInfoMap[std::make_pair(BasePtr, Kind)]
                       : ScopArrayNameMap[BaseName];
-
-  // errs() << "Creating: " << (int)Kind << "\n";
-  // BasePtr->dump();
 
   if (!SAI) {
     auto &DL = getFunction().getParent()->getDataLayout();

--- a/lib/Analysis/ScopInfo.cpp
+++ b/lib/Analysis/ScopInfo.cpp
@@ -339,7 +339,7 @@ ScopArrayInfo::ScopArrayInfo(Value *BasePtr, Type *ElementType, isl::ctx Ctx,
   if (Shape.hasSizes())
     updateSizes(Shape.sizes());
   else
-    updateStrides(Shape.strides(), Shape.offset());
+    updateStrides(Shape.strides(), Shape.sizesPerDim(), Shape.offset());
 
   if (!BasePtr || Kind != MemoryKind::Array) {
     BasePtrOriginSAI = nullptr;
@@ -426,30 +426,32 @@ void ScopArrayInfo::applyAndSetFAD(Value *FAD) {
 }
 
 void ScopArrayInfo::overwriteSizeWithStrides(ArrayRef<const SCEV *> Strides,
+                                             ArrayRef<const SCEV *> SizesPerDim,
                                              const SCEV *Offset) {
 
   // HACK: first set our shape to a stride based shape so that we don't
   // assert within updateStrides. Move this into a bool parameter of
   // updateStrides
-  Shape = ShapeInfo::fromStrides(Strides, Offset);
-  updateStrides(Strides, Offset);
+  Shape = ShapeInfo::fromStrides(Strides, SizesPerDim, Offset);
+  updateStrides(Strides, SizesPerDim, Offset);
 }
 bool ScopArrayInfo::updateStrides(ArrayRef<const SCEV *> Strides,
+                                  ArrayRef<const SCEV *> SizesPerDim,
                                   const SCEV *Offset) {
-  Shape.setStrides(Strides, Offset);
+  Shape.setStrides(Strides, SizesPerDim, Offset);
   DimensionSizesPw.clear();
   for (size_t i = 0; i < Shape.getNumberOfDimensions(); i++) {
-    isl::space Space(S.getIslCtx(), 1, 0);
+    isl::space Space1(S.getIslCtx(), 1, 0);
 
-    std::string param_name = getIslCompatibleName(
+    std::string param_name_1 = getIslCompatibleName(
         "stride_" + std::to_string(i) + "__", getName(), "");
-    isl::id IdPwAff = isl::id::alloc(S.getIslCtx(), param_name, this);
+    isl::id IdPwAff1 = isl::id::alloc(S.getIslCtx(), param_name_1, this);
 
-    Space = Space.set_dim_id(isl::dim::param, 0, IdPwAff);
-    isl::pw_aff PwAff =
-        isl::aff::var_on_domain(isl::local_space(Space), isl::dim::param, 0);
+    Space1 = Space1.set_dim_id(isl::dim::param, 0, IdPwAff1);
+    isl::pw_aff PwAff1 =
+        isl::aff::var_on_domain(isl::local_space(Space1), isl::dim::param, 0);
 
-    DimensionSizesPw.push_back(PwAff);
+    DimensionSizesPw.push_back(PwAff1);
   }
   return true;
 }
@@ -4083,7 +4085,8 @@ ScopArrayInfo *Scop::getOrCreateScopArrayInfo(Value *BasePtr, Type *ElementType,
         LLVM_DEBUG(
             dbgs() << "Shape has strides, SAI had size. Overwriting size "
                       "with strides");
-        SAI->overwriteSizeWithStrides(Shape.strides(), Shape.offset());
+        SAI->overwriteSizeWithStrides(Shape.strides(), Shape.sizesPerDim(),
+                                      Shape.offset());
       } else {
 
         errs() << __PRETTY_FUNCTION__ << "\n"
@@ -4100,7 +4103,7 @@ ScopArrayInfo *Scop::getOrCreateScopArrayInfo(Value *BasePtr, Type *ElementType,
     }
 
     if (SAI->hasStrides()) {
-      SAI->updateStrides(Shape.strides(), Shape.offset());
+      SAI->updateStrides(Shape.strides(), Shape.sizesPerDim(), Shape.offset());
     } else {
       if (!SAI->updateSizes(Shape.sizes()))
         invalidate(DELINEARIZATION, DebugLoc());

--- a/lib/CodeGen/IslExprBuilder.cpp
+++ b/lib/CodeGen/IslExprBuilder.cpp
@@ -449,9 +449,10 @@ Value *IslExprBuilder::createAccessAddress(isl_ast_expr *Expr) {
 
       // If we are outside a kernel, then we do need to synthesize an offset.
       OffsetSCEV = SCEVParameterRewriter::rewrite(OffsetSCEV, SE, Map);
+      // The arguments and their mapped values need to be provided here
       Offset = expandCodeFor(S, SE, DL, "polly", OffsetSCEV,
                              OffsetSCEV->getType(), &*Builder.GetInsertPoint(),
-                             nullptr, StartBlock->getSinglePredecessor());
+                             &GlobalMap, StartBlock->getSinglePredecessor());
       Offset = getLatestValue(Offset);
     }
     assert(Offset && "dimsize uninitialized");

--- a/lib/CodeGen/IslExprBuilder.cpp
+++ b/lib/CodeGen/IslExprBuilder.cpp
@@ -321,7 +321,7 @@ Value *IslExprBuilder::createAccessAddress(isl_ast_expr *Expr) {
       if (Ty != NextIndex->getType())
         NextIndex = Builder.CreateIntCast(NextIndex, Ty, true);
 
-      const SCEV *DimSCEV = SAI->getDimensionStride(u - 1);
+      const SCEV *DimSCEV = SAI->getSizesPerDim(u - 1);
       assert(DimSCEV);
 
       Value *DimSize = nullptr;

--- a/lib/CodeGen/IslNodeBuilder.cpp
+++ b/lib/CodeGen/IslNodeBuilder.cpp
@@ -1241,6 +1241,11 @@ void IslNodeBuilder::materializeStridedArraySizes() {
     Value *Offset = generateSCEV(OffsetSCEV);
     assert(Offset);
     SCEVToValue[OffsetSCEV] = Offset;
+
+    const SCEV *BlockOuterDimSCEV = SE.getOne(Offset->getType());
+    Value *BlockOuterDim = generateSCEV(BlockOuterDimSCEV);
+    assert(BlockOuterDim);
+    SCEVToValue[BlockOuterDimSCEV] = BlockOuterDim;
   }
 }
 

--- a/lib/CodeGen/PPCGCodeGeneration.cpp
+++ b/lib/CodeGen/PPCGCodeGeneration.cpp
@@ -884,8 +884,6 @@ void GPUNodeBuilder::allocateDeviceArrays() {
     }
 
     Value *DevArray = createCallAllocateMemoryForDevice(ArraySize);
-    // Value *DevArray =
-    // createCallAllocateMemoryForDevice(Builder.getInt64(200));
     DevArray->setName(DevArrayName);
     DeviceAllocations[ScopArray] = DevArray;
   }
@@ -1184,7 +1182,6 @@ static bool isPrefix(std::string String, std::string Prefix) {
 Value *GPUNodeBuilder::getArraySize(gpu_array_info *Array) {
   isl::ast_build Build = isl::ast_build::from_context(S.getContext());
   Value *ArraySize = ConstantInt::get(Builder.getInt64Ty(), Array->size);
-  // const auto SAI = (ScopArrayInfo *)(Array->user);
 
   if (!gpu_array_is_scalar(Array)) {
     isl::multi_pw_aff ArrayBound = isl::manage_copy(Array->bound);
@@ -1192,7 +1189,6 @@ Value *GPUNodeBuilder::getArraySize(gpu_array_info *Array) {
     isl::pw_aff OffsetDimZero = ArrayBound.get_pw_aff(0);
     isl::ast_expr Res = Build.expr_from(OffsetDimZero);
 
-    // const unsigned int StartIndex = SAI->hasStrides() ? 0 : 1;
     for (unsigned int i = 1; i < Array->n_index; i++) {
       isl::pw_aff Bound_I = ArrayBound.get_pw_aff(i);
       isl::ast_expr Expr = Build.expr_from(Bound_I);
@@ -1290,10 +1286,8 @@ void GPUNodeBuilder::createDataTransfer(__isl_take isl_ast_node *TransferStmt,
 
   if (Direction == HOST_TO_DEVICE)
     createCallCopyFromHostToDevice(HostPtr, DevPtr, Size);
-  // createCallCopyFromHostToDevice(HostPtr, DevPtr, Builder.getInt64(200));
   else
     createCallCopyFromDeviceToHost(DevPtr, HostPtr, Size);
-  // createCallCopyFromDeviceToHost(DevPtr, HostPtr, Builder.getInt64(200));
 
   isl_id_free(Id);
   isl_ast_expr_free(Arg);
@@ -1549,7 +1543,7 @@ getFunctionsFromRawSubtreeValues(SetVector<Value *> RawSubtreeValues,
 }
 
 // return whether `Array` is used in `Kernel` or not.
-bool isArrayUsedInKernel(ScopArrayInfo *Array, ppcg_kernel *Kernel,
+static bool isArrayUsedInKernel(ScopArrayInfo *Array, ppcg_kernel *Kernel,
                          gpu_prog *Prog) {
   for (int i = 0; i < Prog->n_array; i++) {
     isl_id *Id = isl_space_get_tuple_id(Prog->array[i].space, isl_dim_set);

--- a/lib/Support/ScopHelper.cpp
+++ b/lib/Support/ScopHelper.cpp
@@ -695,7 +695,7 @@ polly::getAbstractIndexingCall(MemAccInst Inst, ScalarEvolution &SE) {
   //// %3 = getelementptr float, float* %0, i64
   //// %bitcast = bitcast %3 to <otherty>
   //// %2 store float 2.000000e+00, float* %3, align 4 STORE <val> (GEP
-  ///<bitcast>) / (CALL index_2(<strides>, <ixs>)))
+  ///< bitcast>) / (CALL index_2(<strides>, <ixs>)))
 
   //// Case 2. (Total size of array statically known)
   //// %4 = tail call i64 @_gfortran_polly_array_index_2(i64 1, i64 5, i64

--- a/lib/Support/ScopHelper.cpp
+++ b/lib/Support/ScopHelper.cpp
@@ -681,3 +681,59 @@ bool polly::hasDebugCall(ScopStmt *Stmt) {
 
   return false;
 }
+
+llvm::Optional<std::pair<CallInst *, GEPOperator *>>
+polly::getAbstractIndexingCall(MemAccInst Inst, ScalarEvolution &SE) {
+  //// TODO: I can get rid of all this crap and use SCEV to drill through the
+  //// bitcasts. Alas, this was written when I was more of an LLVM noob than I
+  //// currently am :)
+  //// TODO: clean this up please.
+
+  //// Case 1. (Total size of array not known)
+  //// %2 = tail call i64 @_gfortran_polly_array_index_2(i64 1, i64 %1, i64
+  //// %indvars.iv1, i64 %indvars.iv) #1
+  //// %3 = getelementptr float, float* %0, i64
+  //// %bitcast = bitcast %3 to <otherty>
+  //// %2 store float 2.000000e+00, float* %3, align 4 STORE <val> (GEP
+  ///<bitcast>) / (CALL index_2(<strides>, <ixs>)))
+
+  //// Case 2. (Total size of array statically known)
+  //// %4 = tail call i64 @_gfortran_polly_array_index_2(i64 1, i64 5, i64
+  //// %indvars.iv1, i64 %indvars.iv) #1 %5 = getelementptr [25 x float], [25 x
+  //// float]* @__m_MOD_g_arr_const_5_5, i64 0, i64 %4 store float 4.200000e+01,
+  //// float* %5, align 4
+
+  Value *MaybeBitcast = Inst.getPointerOperand();
+  if (!MaybeBitcast)
+    return Optional<std::pair<CallInst *, GEPOperator *>>(None);
+
+  //// If we have a bitcast as the parameter to the instruction, strip off the
+  //// bitcast. Otherwise, return the original instruction operand.
+  // Value *MaybeGEP = [&]() -> Value * {
+  //  BitCastOperator *Bitcast = dyn_cast<BitCastOperator>(MaybeBitcast);
+  //  if (Bitcast) {
+  //    return Bitcast->getOperand(0);
+  //  }
+  //  return Inst.getPointerOperand();
+  //}();
+
+  GEPOperator *GEP = dyn_cast<GEPOperator>(MaybeBitcast);
+
+  if (!GEP)
+    return Optional<std::pair<CallInst *, GEPOperator *>>(None);
+
+  auto *MaybeCall = GEP->getOperand(GEP->getNumOperands() - 1);
+  assert(MaybeCall);
+
+  // GEPOperator *GEP = dyn_cast<GEPOperator>(MaybeBitcast);
+  CallInst *Call = dyn_cast<CallInst>(MaybeCall);
+  if (!Call)
+    return Optional<std::pair<CallInst *, GEPOperator *>>(None);
+
+  if (!Call->getCalledFunction()->getName().count(
+          POLLY_ABSTRACT_INDEX_BASENAME))
+    return Optional<std::pair<CallInst *, GEPOperator *>>(None);
+
+  std::pair<CallInst *, GEPOperator *> p = std::make_pair(Call, GEP);
+  return Optional<std::pair<CallInst *, GEPOperator *>>(p);
+}

--- a/lib/Transform/ForwardOpTree.cpp
+++ b/lib/Transform/ForwardOpTree.cpp
@@ -360,9 +360,9 @@ public:
       Subscripts.push_back(nullptr);
     }
 
-    MemoryAccess *Access =
-        new MemoryAccess(Stmt, LI, MemoryAccess::READ, SAI->getBasePtr(),
-                         LI->getType(), true, {}, Sizes, LI, MemoryKind::Array);
+    MemoryAccess *Access = new MemoryAccess(
+        Stmt, LI, MemoryAccess::READ, SAI->getBasePtr(), LI->getType(), true,
+        {}, ShapeInfo::fromSizes(Sizes), LI, MemoryKind::Array);
     S->addAccessFunction(Access);
     Stmt->addAccess(Access, true);
 

--- a/test/GPGPU/chpl_2d_init_shapeinfo_ppcg.ll
+++ b/test/GPGPU/chpl_2d_init_shapeinfo_ppcg.ll
@@ -1,0 +1,55 @@
+;RUN: opt %loadPolly -polly-only-func=test_chpl -polly-codegen-ppcg -polly-invariant-load-hoisting -analyze < %s
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+%array_ty = type { i64, %array_ptr*, i8 }
+%array_ptr = type { [2 x i64], [2 x i64], [2 x i64], i64, double*, double*, i8 }
+
+; Function Attrs: readnone
+define internal i64 @polly_array_index(i64 %arg1, i64 %arg2, i64 %arg3, i64 %arg4, i64 %arg5) #0 {
+  %tmp = mul nsw i64 %arg4, %arg2
+  %tmp8 = add nsw i64 %tmp, %arg1
+  %tmp9 = mul nsw i64 %arg5, %arg3
+  %tmp10 = add nsw i64 %tmp8, %tmp9
+  ret i64 %tmp10
+}
+
+
+; Function Attrs: noinline
+define weak dso_local void @test_chpl(%array_ty* nonnull %arg) #1 {
+bb:
+  br label %bb23
+
+bb23:                                             ; preds = %bb, %bb37
+  %.0 = phi i64 [ 0, %bb ], [ %tmp38, %bb37 ]
+  br label %bb24
+
+bb24:                                             ; preds = %bb23, %bb24
+  %.01 = phi i64 [ 0, %bb23 ], [ %tmp36, %bb24 ]
+  %tmp25 = getelementptr inbounds %array_ty, %array_ty* %arg, i64 0, i32 1
+  %tmp26 = load %array_ptr*, %array_ptr** %tmp25, align 8
+  %tmp27 = getelementptr inbounds %array_ptr, %array_ptr* %tmp26, i64 0, i32 1, i64 1
+  store i64 1, i64* %tmp27, align 8
+  %tmp28 = getelementptr inbounds %array_ptr, %array_ptr* %tmp26, i64 0, i32 1, i64 0
+  %tmp29 = load i64, i64* %tmp28, align 8
+  %tmp30 = call i64 @polly_array_index(i64 0, i64 %tmp29, i64 1, i64 %.0, i64 %.01)
+  %tmp31 = getelementptr inbounds %array_ptr, %array_ptr* %tmp26, i64 0, i32 5
+  %tmp32 = load double*, double** %tmp31, align 8
+  %tmp33 = getelementptr inbounds double, double* %tmp32, i64 %tmp30
+  %tmp34 = add nuw nsw i64 %.01, %.0
+  %tmp35 = sitofp i64 %tmp34 to double
+  store double %tmp35, double* %tmp33, align 8
+  %tmp36 = add nuw nsw i64 %.01, 1
+  %exitcond = icmp ne i64 %tmp36, 1000
+  br i1 %exitcond, label %bb24, label %bb37
+
+bb37:                                             ; preds = %bb24
+  %tmp38 = add nuw nsw i64 %.0, 1
+  %exitcond8 = icmp ne i64 %tmp38, 1000
+  br i1 %exitcond8, label %bb23, label %bb39
+
+bb39:                                             ; preds = %bb37
+  ret void
+}
+
+attributes #0 = { readnone }
+attributes #1 = { noinline }

--- a/test/ScopInfo/chpl_2d_init_shapeinfo.ll
+++ b/test/ScopInfo/chpl_2d_init_shapeinfo.ll
@@ -1,0 +1,55 @@
+;RUN: opt %loadPolly -polly-only-func=test_chpl -polly-scops -polly-invariant-load-hoisting -analyze < %s
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+%array_ty = type { i64, %array_ptr*, i8 }
+%array_ptr = type { [2 x i64], [2 x i64], [2 x i64], i64, double*, double*, i8 }
+
+; Function Attrs: readnone
+define internal i64 @polly_array_index(i64 %arg1, i64 %arg2, i64 %arg3, i64 %arg4, i64 %arg5) #0 {
+  %tmp = mul nsw i64 %arg4, %arg2
+  %tmp8 = add nsw i64 %tmp, %arg1
+  %tmp9 = mul nsw i64 %arg5, %arg3
+  %tmp10 = add nsw i64 %tmp8, %tmp9
+  ret i64 %tmp10
+}
+
+
+; Function Attrs: noinline
+define weak dso_local void @test_chpl(%array_ty* nonnull %arg) #1 {
+bb:
+  br label %bb23
+
+bb23:                                             ; preds = %bb, %bb37
+  %.0 = phi i64 [ 0, %bb ], [ %tmp38, %bb37 ]
+  br label %bb24
+
+bb24:                                             ; preds = %bb23, %bb24
+  %.01 = phi i64 [ 0, %bb23 ], [ %tmp36, %bb24 ]
+  %tmp25 = getelementptr inbounds %array_ty, %array_ty* %arg, i64 0, i32 1
+  %tmp26 = load %array_ptr*, %array_ptr** %tmp25, align 8
+  %tmp27 = getelementptr inbounds %array_ptr, %array_ptr* %tmp26, i64 0, i32 1, i64 1
+  store i64 1, i64* %tmp27, align 8
+  %tmp28 = getelementptr inbounds %array_ptr, %array_ptr* %tmp26, i64 0, i32 1, i64 0
+  %tmp29 = load i64, i64* %tmp28, align 8
+  %tmp30 = call i64 @polly_array_index(i64 0, i64 %tmp29, i64 1, i64 %.0, i64 %.01)
+  %tmp31 = getelementptr inbounds %array_ptr, %array_ptr* %tmp26, i64 0, i32 5
+  %tmp32 = load double*, double** %tmp31, align 8
+  %tmp33 = getelementptr inbounds double, double* %tmp32, i64 %tmp30
+  %tmp34 = add nuw nsw i64 %.01, %.0
+  %tmp35 = sitofp i64 %tmp34 to double
+  store double %tmp35, double* %tmp33, align 8
+  %tmp36 = add nuw nsw i64 %.01, 1
+  %exitcond = icmp ne i64 %tmp36, 1000
+  br i1 %exitcond, label %bb24, label %bb37
+
+bb37:                                             ; preds = %bb24
+  %tmp38 = add nuw nsw i64 %.0, 1
+  %exitcond8 = icmp ne i64 %tmp38, 1000
+  br i1 %exitcond8, label %bb23, label %bb39
+
+bb39:                                             ; preds = %bb37
+  ret void
+}
+
+attributes #0 = { readnone }
+attributes #1 = { noinline }


### PR DESCRIPTION
There were a few instances `Sizes` not handled properly. These have now been replaced with Shapes.sizes(). 
The polly regression tests are now passing.